### PR TITLE
🧹 [code health improvement] Rename parameter 'type' to avoid shadowing built-in

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -539,9 +539,9 @@ print(f"Investment priorities: {summary.investment_priorities}")
 #### Asset
 ```python
 class Asset:
-    def __init__(self, name, type, value, location, dependencies):
+    def __init__(self, name, asset_type, value, location, dependencies):
         self.name = name
-        self.type = type  # physical, software, data, function
+        self.type = asset_type  # physical, software, data, function
         self.value = value
         self.location = location
         self.dependencies = dependencies
@@ -552,9 +552,9 @@ class Asset:
 #### Threat
 ```python
 class Threat:
-    def __init__(self, name, type, likelihood, impact, description):
+    def __init__(self, name, threat_type, likelihood, impact, description):
         self.name = name
-        self.type = type
+        self.type = threat_type
         self.likelihood = likelihood
         self.impact = impact
         self.description = description
@@ -565,9 +565,9 @@ class Threat:
 #### AttackNode
 ```python
 class AttackNode:
-    def __init__(self, name, type, prerequisites, difficulty, cost):
+    def __init__(self, name, node_type, prerequisites, difficulty, cost):
         self.name = name
-        self.type = type  # root, intermediate, leaf
+        self.type = node_type  # root, intermediate, leaf
         self.prerequisites = prerequisites
         self.difficulty = difficulty
         self.cost = cost


### PR DESCRIPTION
🎯 **What:**
Renamed the `type` parameter in the `__init__` methods of `AttackNode`, `Asset`, and `Threat` classes within the `API_DOCUMENTATION.md` file to `node_type`, `asset_type`, and `threat_type` respectively. 

💡 **Why:**
The parameter name `type` shadows the built-in Python function `type()`. Using built-in function names as variable or parameter names is a poor practice as it can lead to confusion and potential bugs if someone tries to use the built-in function within that scope. This change improves code health and maintainability of the examples.

✅ **Verification:**
Manually verified that the parameter name was changed in the `__init__` signature, and the assignment `self.type = <new_name>` was correctly updated. A code review was performed and rated as "Correct".

✨ **Result:**
The documentation examples now follow better Python coding practices by avoiding the shadowing of built-in functions, making them safer to copy-paste or reference for actual implementations.

---
*PR created automatically by Jules for task [1073588350151721875](https://jules.google.com/task/1073588350151721875) started by @randomwalkdr*